### PR TITLE
Add character set to CopyrightText

### DIFF
--- a/s2.asm
+++ b/s2.asm
@@ -4133,8 +4133,8 @@ TailsNameCheat_Buttons:
 ; ArtNem_3DF4:
 ArtNem_Player1VS2:	BINCLUDE	"art/nemesis/1Player2VS.bin"
 
-	charset '0','9',0 ; Add charset for numbers
-	charset 'A','Z',$E ; Add charset for letters
+	charset '0','9',0 ; Add character set for numbers
+	charset 'A','Z',$E ; Add character set for letters
 
 ; word_3E82:
 CopyrightText:
@@ -4151,7 +4151,7 @@ CopyrightText:
 	dc.w  make_art_tile(ArtTile_ArtNem_FontStuff_TtlScr + 'A',0,0)	; A
 CopyrightText_End:
 
-    charset
+    charset ; Revert character set
 
     if ~~removeJmpTos
 ; sub_3E98:

--- a/s2.asm
+++ b/s2.asm
@@ -4133,19 +4133,22 @@ TailsNameCheat_Buttons:
 ; ArtNem_3DF4:
 ArtNem_Player1VS2:	BINCLUDE	"art/nemesis/1Player2VS.bin"
 
+	charset '0','9',0 ; Add charset for numbers
+	charset 'A','Z',$E ; Add charset for letters
+
 ; word_3E82:
 CopyrightText:
 	dc.w  make_art_tile(ArtTile_ArtNem_FontStuff_TtlScr + $0B,0,0)	; (C)
 	dc.w  make_art_tile(ArtTile_VRAM_Start,0,0)	;
-	dc.w  make_art_tile(ArtTile_ArtNem_FontStuff_TtlScr + $01,0,0)	; 1
-	dc.w  make_art_tile(ArtTile_ArtNem_FontStuff_TtlScr + $09,0,0)	; 9
-	dc.w  make_art_tile(ArtTile_ArtNem_FontStuff_TtlScr + $09,0,0)	; 9
-	dc.w  make_art_tile(ArtTile_ArtNem_FontStuff_TtlScr + $02,0,0)	; 2
+	dc.w  make_art_tile(ArtTile_ArtNem_FontStuff_TtlScr + '1',0,0)	; 1
+	dc.w  make_art_tile(ArtTile_ArtNem_FontStuff_TtlScr + '9',0,0)	; 9
+	dc.w  make_art_tile(ArtTile_ArtNem_FontStuff_TtlScr + '9',0,0)	; 9
+	dc.w  make_art_tile(ArtTile_ArtNem_FontStuff_TtlScr + '2',0,0)	; 2
 	dc.w  make_art_tile(ArtTile_VRAM_Start,0,0)	;
-	dc.w  make_art_tile(ArtTile_ArtNem_FontStuff_TtlScr + $20,0,0)	; S
-	dc.w  make_art_tile(ArtTile_ArtNem_FontStuff_TtlScr + $12,0,0)	; E
-	dc.w  make_art_tile(ArtTile_ArtNem_FontStuff_TtlScr + $14,0,0)	; G
-	dc.w  make_art_tile(ArtTile_ArtNem_FontStuff_TtlScr + $0E,0,0)	; A
+	dc.w  make_art_tile(ArtTile_ArtNem_FontStuff_TtlScr + 'S',0,0)	; S
+	dc.w  make_art_tile(ArtTile_ArtNem_FontStuff_TtlScr + 'E',0,0)	; E
+	dc.w  make_art_tile(ArtTile_ArtNem_FontStuff_TtlScr + 'G',0,0)	; G
+	dc.w  make_art_tile(ArtTile_ArtNem_FontStuff_TtlScr + 'A',0,0)	; A
 CopyrightText_End:
 
     if ~~removeJmpTos

--- a/s2.asm
+++ b/s2.asm
@@ -4151,6 +4151,8 @@ CopyrightText:
 	dc.w  make_art_tile(ArtTile_ArtNem_FontStuff_TtlScr + 'A',0,0)	; A
 CopyrightText_End:
 
+    charset
+
     if ~~removeJmpTos
 ; sub_3E98:
 JmpTo_SwScrl_Title 


### PR DESCRIPTION
I believe this would document the CopyrightText data better than tossing in comments, and it makes it easier to tell which part of the macro is the text. This is based off of a similar thing I did in my hack after MainMemory and I had a discussion in IRC about the mapping of the text and numbers.