### PR TITLE
Updated ConvertCollisionArray documentation

### DIFF
--- a/s2.asm
+++ b/s2.asm
@@ -40481,9 +40481,12 @@ loc_1EAE0:
 ; End of function FindWall2
 
 ; ---------------------------------------------------------------------------
-; The subroutine converts a raw bitmap-like collision block data and
-; converts them into the proper collision arrays. Pointers to said raw data
-; are dummied out.
+; This subroutine takes 'raw' bitmap-like collision block data as input and
+; converts it into the proper collision arrays (ColArray and ColArray2).
+; Pointers to said raw data are dummied out.
+; Curiously, an example of the original 'raw' data that this was intended
+; to process can be found in the J2ME version of Sonic 1, in a file called
+; 'blkcol.bct'.
 ; This subroutine exists in Sonic 1 as well, but was oddly changed in
 ; the S2 Nick Arcade prototype to just handle loading GHZ's collision
 ; instead (though it too is dummied out, hence collision being broken).
@@ -40498,7 +40501,7 @@ ConvRowColBlocks	= ColArray
 ConvertCollisionArray:
 	rts
 ; ---------------------------------------------------------------------------
-	; The raw format is stores the collision data column by column, for the normal collision array.
+	; The raw format stores the collision data column by column for the normal collision array.
 	; This makes a copy of the data, but stored row by row, for the rotated collision array.
 	lea	(RawColBlocks).l,a1	; Source location of raw collision block data
 	lea	(ConvRowColBlocks).l,a2	; Destinatation location for row-converted collision block data

--- a/s2.asm
+++ b/s2.asm
@@ -40482,7 +40482,7 @@ loc_1EAE0:
 
 ; ---------------------------------------------------------------------------
 ; The subroutine converts a raw bitmap-like collision block data and
-; converts them into width/height arrays. Pointers to said raw data
+; converts them into the proper collision arrays. Pointers to said raw data
 ; are dummied out.
 ; This subroutine exists in Sonic 1 as well, but was oddly changed in
 ; the S2 Nick Arcade prototype to just handle loading GHZ's collision


### PR DESCRIPTION
So, here's a quick story. I noticed a filed called "blkcol.bct" that was in the J2ME version of Sonic 1 and subsequent versions of it. After looking into it, it turned out to be the raw collision block data, stored in a bitmap-like format. I recalled a format like this in the comments for ConvertCollisionArray in this disassembly. After tinkering about with the function, I managed to get it working, and sure enough, it produced the same width/height arrays found in Sonic 1.

As it turns out, the function is not really built to overwrite the data over itself at all. Rather what it's doing is that it's making a copy of the raw collision data, but stored in rows instead of columns, and then those get converted into the proper collision arrays, with the raw column-formatted data converted into the height/normal collision array, and the row-formatted data converted into the width/rotated collision array. The pointers to the raw collision data are just dummied out.

Whether it was really writing everything to ROM or not, though, I'm not sure.