### PR TITLE
Added object argument

### DIFF
--- a/build_tools/Lua/common.lua
+++ b/build_tools/Lua/common.lua
@@ -121,7 +121,8 @@ local function assemble_file(input_filename, output_filename, as_path, p2bin_pat
 	-- '-E'   - output errors to a file (*.log)
 	-- '-i .' - allows (b)include paths to be absolute
 	-- '-c'   - outputs a shared file (*.h)
-	os.execute(as_path .. " -xx -n -q -A -L -U -E -i . " .. (create_header and "-c " or " ") .. asm_filename)
+	-- '-o'	  - sets the object filename
+	os.execute(as_path .. " -xx -n -q -A -L -U -E -i . " .. (create_header and "-c " or " ") .. asm_filename .. " -o " .. object_filename)
 
 	-- If the assembler encountered an error, then the object file will not exist.
 	if not file_exists(object_filename) then


### PR DESCRIPTION
This makes sure the output object is named what we expect since AS seems to read the filename up to the first period for the extension rather than the last one
(e.g. s2.something.asm would emit s2,p rather than s2.something.p)