### PR TITLE
Adding in more bug fixes

### DIFF
--- a/mappings/sprite/objC6_b.asm
+++ b/mappings/sprite/objC6_b.asm
@@ -10,11 +10,11 @@ Map_objC6_b_0008:	spriteHeader
 	spritePiece	-8, 0, 2, 4, 0, 0, 0, 0, 0
     else
 	; This also uses the wrong door mappings!
-    endif
 	spritePiece	-8, -$20, 2, 2, 0, 0, 0, 0, 0
 	spritePiece	-8, -$10, 2, 2, 0, 0, 0, 0, 0
 	spritePiece	-8, 0, 2, 2, 0, 0, 0, 0, 0
 	spritePiece	-8, $10, 2, 2, 0, 0, 0, 0, 0
+    endif
 Map_objC6_b_0008_End
 
 Map_objC6_b_002A:	spriteHeader

--- a/mappings/sprite/objC6_b.asm
+++ b/mappings/sprite/objC6_b.asm
@@ -5,16 +5,10 @@ Map_objC6_b:	mappingsTable
 	mappingsTableEntry.w	Map_objC6_b_0056
 
 Map_objC6_b_0008:	spriteHeader
-    if fixBugs
-	spritePiece	-8, -$20, 2, 4, 0, 0, 0, 0, 0
-	spritePiece	-8, 0, 2, 4, 0, 0, 0, 0, 0
-    else
-	; This also uses the wrong door mappings!
 	spritePiece	-8, -$20, 2, 2, 0, 0, 0, 0, 0
 	spritePiece	-8, -$10, 2, 2, 0, 0, 0, 0, 0
 	spritePiece	-8, 0, 2, 2, 0, 0, 0, 0, 0
 	spritePiece	-8, $10, 2, 2, 0, 0, 0, 0, 0
-    endif
 Map_objC6_b_0008_End
 
 Map_objC6_b_002A:	spriteHeader

--- a/mappings/sprite/objC6_b.asm
+++ b/mappings/sprite/objC6_b.asm
@@ -5,6 +5,12 @@ Map_objC6_b:	mappingsTable
 	mappingsTableEntry.w	Map_objC6_b_0056
 
 Map_objC6_b_0008:	spriteHeader
+    if fixBugs
+	spritePiece	-8, -$20, 2, 4, 0, 0, 0, 0, 0
+	spritePiece	-8, 0, 2, 4, 0, 0, 0, 0, 0
+    else
+	; This also uses the wrong door mappings!
+    endif
 	spritePiece	-8, -$20, 2, 2, 0, 0, 0, 0, 0
 	spritePiece	-8, -$10, 2, 2, 0, 0, 0, 0, 0
 	spritePiece	-8, 0, 2, 2, 0, 0, 0, 0, 0

--- a/s2.asm
+++ b/s2.asm
@@ -65015,6 +65015,15 @@ Obj89_Arrow_Platform:
 	move.w	#2,d3
 	move.w	x_pos(a0),d4
 	jsrto	JmpTo8_PlatformObject
+    if fixBugs
+	; AI Tails normally does not cause the arrow they are standing on
+	; to fall, this fixes that.
+	btst	#status.npc.p2_standing,status(a0)	; is Tails standing on the arrow?
+	beq.s	.notTails				; if not, branch
+	move.w	#$1F,obj89_arrow_timer(a0)		; else, set timer
+
+.notTails:
+    endif
 	btst	#status.npc.p1_standing,status(a0)	; is Sonic standing on the arrow?
 	beq.s	return_30D02				; if not, branch
 	move.w	#$1F,obj89_arrow_timer(a0)		; else, set timer

--- a/s2.asm
+++ b/s2.asm
@@ -70322,6 +70322,10 @@ loc_35150:
 	moveq	#$1E,d0
 
 loc_35164:
+    if fixBugs
+	; Save the last animation value to elsewhere, related to a bugfix below.
+	move.b	anim(a0),objoff_23(a0)
+    endif
 	move.b	byte_35180(pc,d0.w),anim(a0)
 
 return_3516A:
@@ -70574,8 +70578,21 @@ BranchTo_JmpTo63_DeleteObject ; BranchTo
 ; ===========================================================================
 
 loc_3539E:
+    if fixBugs
+	; anim_frame_duration causes many of the animations to look far choppier
+	; than they should, or appear inconsistent. To solve this, we will store
+	; the proper animation elsewhere and stop decrementing the frame duration
+	; until both match up.
+	move.b	objoff_23(a0),d0
+	cmp.b	anim(a0),d0
+	bne.s	.skip
+    endif
 	subq.b	#1,anim_frame_duration(a0)
 	bpl.s	return_353E8
+    if fixBugs
+.skip:
+	move.b	anim(a0),objoff_23(a0)
+    endif
 	moveq	#0,d0
 	move.b	anim(a0),d0
 	add.w	d0,d0

--- a/s2.asm
+++ b/s2.asm
@@ -17,14 +17,14 @@
 ; >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 ; ASSEMBLY OPTIONS:
 ;
-gameRevision = 1
+gameRevision = 0
 ;	| If 0, a REV00 ROM is built
 ;	| If 1, a REV01 ROM is built, which contains some fixes
 ;	| If 2, a (theoretical) REV02 ROM is built, which contains even more fixes
 padToPowerOfTwo = 1
 ;	| If 1, pads the end of the ROM to the next power of two bytes (for real hardware)
 ;
-fixBugs = 0
+fixBugs = 1
 ;	| If 1, enables all bug-fixes
 ;	| See also the 'FixDriverBugs' flag in 's2.sounddriver.asm'
 ;	| See also the 'FixMusicAndSFXDataBugs' flag in 'build.lua'
@@ -64470,6 +64470,14 @@ Obj89_Main_DropHammer:
 	cmpi.w	#$78,(Boss_Countdown).w
 	bgt.s	return_3088A			; wait until timer is below $78
 	subi_.w	#1,sub3_x_pos(a0)		; make hammer move left
+    if fixBugs
+	; This properly makes the hammer fall the opposite direction.
+	btst	#render_flags.x_flip,render_flags(a0)	; is Eggman facing right?
+	beq.s	.notfacingright			; is not, branch
+	addi_.w	#2,sub3_x_pos(a0)		; make the hammer move right
+
+.notfacingright:
+    endif
 	move.l	obj89_hammer_y_pos(a0),d0
 	move.w	obj89_hammer_y_vel(a0),d1
 	addi.w	#$38,obj89_hammer_y_vel(a0)	; add gravity
@@ -65348,8 +65356,21 @@ Obj57_TransferPositions:
 ;loc_31358:
 Obj57_FallApart:	; make the digger thingies fall down
 	cmpi.w	#$78,(Boss_Countdown).w
+    if ~~fixBugs
 	bgt.s	return_313C4
+    else
+	; Not actually a bugfix, but the code below pushed this branch out of range.
+	bgt.w	return_313C4
+    endif
 	subi_.w	#1,sub5_x_pos(a0)
+    if fixBugs
+	; This properly makes the left drill fall the opposite direction.
+	btst	#render_flags.x_flip,render_flags(a0)	; is Eggman facing right?
+	beq.s	.notfacingright			; is not, branch
+	addi_.w	#2,sub5_x_pos(a0)
+
+.notfacingright:
+    endif
 	move.l	obj57_sub5_y_pos2(a0),d0
 	move.w	obj57_sub5_y_vel(a0),d1
 	addi.w	#$38,obj57_sub5_y_vel(a0)
@@ -65363,6 +65384,14 @@ Obj57_FallApart:	; make the digger thingies fall down
 	move.w	#0,obj57_sub5_y_vel(a0)
 +			; second one
 	addi_.w	#1,sub2_x_pos(a0)
+    if fixBugs
+	; This properly makes the right drill fall the opposite direction.
+	btst	#render_flags.x_flip,render_flags(a0)	; is Eggman facing right?
+	beq.s	.notfacingright2			; is not, branch
+	subi_.w	#2,sub5_x_pos(a0)
+
+.notfacingright2:
+    endif
 	move.l	obj57_sub2_y_pos2(a0),d0
 	move.w	obj57_sub2_y_vel(a0),d1
 	addi.w	#$38,obj57_sub2_y_vel(a0)
@@ -66201,8 +66230,21 @@ loc_31E76:
 
 loc_31EAE:
 	cmpi.w	#$78,(Boss_Countdown).w
+    if ~~fixBugs
 	bgt.s	return_31F22
+    else
+	; Not actually a bugfix, but the code below pushed this branch out of range.
+	bgt.w	return_31F22
+    endif
 	subi_.w	#1,sub5_x_pos(a0)
+    if fixBugs
+	; This properly makes the left electricity generator fall the opposite direction.
+	btst	#render_flags.x_flip,render_flags(a0)	; is Eggman facing right?
+	beq.s	.notfacingright			; is not, branch
+	addi_.w	#2,sub5_x_pos(a0)
+
+.notfacingright:
+    endif
 	move.l	objoff_3A(a0),d0
 	move.w	objoff_2E(a0),d1
 	addi.w	#$38,objoff_2E(a0)
@@ -66219,6 +66261,14 @@ loc_31EE8:
 	cmpi.w	#60,(Boss_Countdown).w
 	bgt.s	return_31F22
 	addi_.w	#1,sub2_x_pos(a0)
+    if fixBugs
+	; This properly makes the right electricity generator fall the opposite direction.
+	btst	#render_flags.x_flip,render_flags(a0)	; is Eggman facing right?
+	beq.s	.notfacingright2		; is not, branch
+	subi_.w	#2,sub2_x_pos(a0)
+
+.notfacingright2:
+    endif
 	move.l	objoff_34(a0),d0
 	move.w	objoff_30(a0),d1
 	addi.w	#$38,objoff_30(a0)

--- a/s2.asm
+++ b/s2.asm
@@ -62157,7 +62157,15 @@ Obj5D_Gunk_States:	offsetTable
 
 Obj5D_Gunk_Init:
 	addq.b	#2,routine_secondary(a0)	; => Obj5D_Gunk_Main
+    if fixBugs
+	move.b	#$16,y_radius(a0)
+    else
+	; The hitbox for this object is a mess, allowing the player to avoid
+	; damage by simply ducking. Ideally, it would be realigned with the
+	; sprite, but this will have to do for now.
+	; Funnily enough, the Official Players Guide brings this up on page 90.
 	move.b	#$20,y_radius(a0)
+    endif
 	move.b	#$19,anim(a0)
 	move.w	#0,y_vel(a0)
 	movea.l	Obj5D_parent(a0),a1 ; a1=object

--- a/s2.asm
+++ b/s2.asm
@@ -24159,11 +24159,21 @@ Obj2D_Init:
 	bne.s	+
 	move.w	#make_art_tile(ArtTile_ArtNem_ConstructionStripes_2,1,0),art_tile(a0)
 	move.b	#8,width_pixels(a0)
+    if fixBugs
+	; This is sort of a hack. Chemical Plant and Death Egg use the wrong subtype,
+	; so a more proper fix would be to replace all instances with subtype 3.
+	move.b	#3,subtype(a0)
+    endif
 +
 	cmpi.b	#death_egg_zone,(Current_Zone).w
 	bne.s	+
 	move.w	#make_art_tile(ArtTile_ArtNem_ConstructionStripes_1,1,0),art_tile(a0)
 	move.b	#8,width_pixels(a0)
+    if fixBugs
+	; This is sort of a hack. Chemical Plant and Death Egg use the wrong subtype,
+	; so a more proper fix would be to replace all instances with subtype 3.
+	move.b	#3,subtype(a0)
+    endif
 +
 	cmpi.b	#aquatic_ruin_zone,(Current_Zone).w
 	bne.s	+

--- a/s2.asm
+++ b/s2.asm
@@ -27476,7 +27476,13 @@ Obj39_SlideIn:
 Obj39_SetTimer:
 	move.w	#$2D0,anim_frame_duration(a0)
 	addq.b	#2,routine(a0)
+    if fixBugs
+	bra.w	DisplaySprite
+    else
+	; There should be a branch to DisplaySprite here, but there isn't,
+	; causing a one-frame flicker when the two words combine.
 	rts
+    endif
 ; ===========================================================================
 ; loc_13FEE:
 Obj39_Wait:

--- a/s2.asm
+++ b/s2.asm
@@ -46342,6 +46342,12 @@ Obj84_MainY:
 	lea	(MainCharacter).w,a1 ; a1=character
 	bsr.s	+
 	lea	(Sidekick).w,a1 ; a1=character
+    if fixBugs
+	; AI Tails can behave rather strangely if he happens to be flying into
+	; an autoroll object, most visible in Casino Night.
+	cmpi.w	#4,(Tails_CPU_routine).w	; TailsCPU_Flying
+	beq.s	return_21350
+    endif
 +
 	tst.b	(a2)+
 	bne.s	Obj84_MainY_Alt
@@ -48023,6 +48029,12 @@ loc_22688:
 	move.w	(a2)+,d5
 	add.w	y_pos(a0),d5
 	addq.b	#2,(a4)
+    if fixBugs
+	; If Sonic/Tails end up getting damaged into a pipe, they will
+	; be constantly displaced due to how the hurt routine works. This
+	; fixes the bug by forcing them back into their normal state.
+	move.b	#2,routine(a1)
+    endif
 	move.b	#$81,obj_control(a1)
 	move.b	#AniIDSonAni_Roll,anim(a1)
 	move.w	#$800,inertia(a1)

--- a/s2.asm
+++ b/s2.asm
@@ -17,14 +17,14 @@
 ; >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 ; ASSEMBLY OPTIONS:
 ;
-gameRevision = 0
+gameRevision = 1
 ;	| If 0, a REV00 ROM is built
 ;	| If 1, a REV01 ROM is built, which contains some fixes
 ;	| If 2, a (theoretical) REV02 ROM is built, which contains even more fixes
 padToPowerOfTwo = 1
 ;	| If 1, pads the end of the ROM to the next power of two bytes (for real hardware)
 ;
-fixBugs = 1
+fixBugs = 0
 ;	| If 1, enables all bug-fixes
 ;	| See also the 'FixDriverBugs' flag in 's2.sounddriver.asm'
 ;	| See also the 'FixMusicAndSFXDataBugs' flag in 'build.lua'

--- a/s2.asm
+++ b/s2.asm
@@ -51228,17 +51228,30 @@ Obj2B_Init:
 	move.l	#Obj2B_MapUnc_25C6E,mappings(a0)
 	move.w	#make_art_tile(ArtTile_ArtKos_LevelArt,1,0),art_tile(a0)
 	jsrto	JmpTo25_Adjust2PArtPointer
+    if fixBugs
+	ori.b	#1<<render_flags.level_fg|1<<render_flags.explicit_height,render_flags(a0)
+	move.b	#$1C,width_pixels(a0)
+	move.b	#$20,y_radius(a0)
+    else
+	; This should use the accurate height check and larger size values, since
+	; right now it vanishes whilst partially on-screen.
 	ori.b	#1<<render_flags.level_fg,render_flags(a0)
 	move.b	#$10,width_pixels(a0)
 	move.b	#$18,y_radius(a0)
+    endif
 	move.b	#4,priority(a0)
 ; loc_25A9C:
 Obj2B_Main:
 	move.w	x_pos(a0),-(sp)
 	bsr.w	loc_25B28
+    if fixBugs
+	moveq	#$10+$B,d1
+    else
+	; Read above.
 	moveq	#0,d1
 	move.b	width_pixels(a0),d1
 	addi.w	#$B,d1
+    endif
 	moveq	#0,d2
 	move.b	y_radius(a0),d2
 	move.w	d2,d3
@@ -56548,7 +56561,11 @@ Obj82_Properties:
 	;    width_pixels
 	;        y_radius
 	dc.b $20,  8	; 0
+    if fixBugs
+	dc.b $1C,$32	; 2
+    else
 	dc.b $1C,$30	; 2
+    endif
 	; Unused and broken; these don't have an associated frame, so using them crashes the game
 	dc.b $10,$10	; 4
 	dc.b $10,$10	; 6
@@ -56559,7 +56576,12 @@ Obj82_Init:
 	move.l	#Obj82_MapUnc_2A476,mappings(a0)
 	move.w	#make_art_tile(ArtTile_ArtKos_LevelArt,0,0),art_tile(a0)
 	jsrto	JmpTo46_Adjust2PArtPointer
+    if fixBugs
+	ori.b	#1<<render_flags.level_fg|1<<render_flags.explicit_height,render_flags(a0)
+    else
+	; Same as Obj2B, this should use the accurate height flag.
 	move.b	#1<<render_flags.level_fg,render_flags(a0)
+    endif
 	move.b	#3,priority(a0)
 	moveq	#0,d0
 	move.b	subtype(a0),d0
@@ -56599,6 +56621,13 @@ Obj82_Main:
 	move.b	y_radius(a0),d2
 	move.w	d2,d3
 	addq.w	#1,d3
+    if fixBugs
+	tst.b	mapping_frame(a0)	; is this a pillar?
+	beq.s	.notPillar		; if not, branch
+	subq.w	#2,d3
+
+.notPillar:
+    endif
 	jsrto	JmpTo23_SolidObject
 	swap	d6
 	move.b	d6,objoff_3F(a0)

--- a/s2.constants.asm
+++ b/s2.constants.asm
@@ -127,6 +127,7 @@ objoff_10 =		x_vel
 objoff_14 =		inertia+0
 objoff_15 =		inertia+1
 objoff_1F =		anim_frame_duration+1
+objoff_23 =		respawn_index
 objoff_27 =		$27
 objoff_28 =		subtype ; overlaps subtype, but a few objects use it for other things anyway
  enum               objoff_29=$29,objoff_2A=$2A,objoff_2B=$2B,objoff_2C=$2C,objoff_2D=$2D,objoff_2E=$2E,objoff_2F=$2F


### PR DESCRIPTION
Added a number of corrections from the [fix it megathread](https://forums.sonicretro.org/threads/some-changes-and-fixes-for-sonic-2.29029/) that are missing from the disassembly; in order of appliance:

- ARZ, CNZ, and MCZ not having their parts fall in the correct directions
- Being able to duck and avoid getting hit by the CPZ boss gunk ([though the hitbox in general is very unaligned with the sprite](https://media.discordapp.net/attachments/201554087299252225/1401853857188941855/image0.jpg?ex=68927264&is=689120e4&hm=56316bbd30456ef94d2d007bd279bd93be7f968ae464a1ca3f90f880336980fd), so this may need to be reworked in the future).
- ARZ Eggman not laughing until the player has hit the ground.
- Being able to walk on air after the ARZ boss if one player is standing on a pillar when the finishing blow is dealt.
- AI Tails not causing the ARZ arrows to fall. While it is _possible_ that this was intentionally done, given that AI Tails can influence just about every other object in the game, this is likely an oversight.
- Tails behaving strangely if he spawns in an autoroll object.
- CPZ pipes behaving strangely if the player is damaged into one.
- The OOZ boss crashing if the player deals the finishing blow on the same frame they submerge completely.
- The MTZ boss crashing if the second player hits a balloon two frames after the first player is hit.
- The GAME/TIME OVER text flickering for one frame.
- The ARZ pillars vanishing whilst still partially on-screen.
- The CPZ/DEZ doors not appearing correctly. Ideally, the layouts would be modified, but for now we'll just 'force' the value to the correct one. The DEZ door just before Eggman also needed to have its mappings modified since it is a separate object.

**EDIT:** Also added a fix for the incorrect Special Stage animations, as shown [here](https://forums.sonicretro.org/threads/sonic-2-special-stage-bug-tiny-bombs.40320/).