### PR TITLE
Document a Sonic 1 leftover in the sound driver.

### DIFF
--- a/s2.sounddriver.asm
+++ b/s2.sounddriver.asm
@@ -3016,6 +3016,8 @@ cfPanningAMSFMS:
 	; change the panning of a given channel.
 
 	bit	7,(ix+zTrack.VoiceControl)	; Is this a PSG track?
+	; The following return check is a leftover from Sonic 1, where it returns if VoiceControl is negative (i.e. 80h or higher).
+	; A not zero check would make this more consistent with the rest of the sound driver.
 	ret	m				; If so, quit!
     if ~~FixDriverBugs
 	; This check is in the wrong place.


### PR DESCRIPTION
Effectively not a bug but rather documentation of a line that caught me by surprise.