### PR TITLE
Document ObjC1 and minor bug fixes

### DIFF
--- a/s2.asm
+++ b/s2.asm
@@ -63780,10 +63780,19 @@ Obj52_Mobile_Flamethrower:
 	move.b	#$2F,objoff_3E(a0)
 
 loc_2FDAA:
+    if ~~fixBugs
+	; This branch is in the wrong place. Should the player defeat Eggman right as
+	; the flamethrower finishes, AnimateBoss will increment `boss_routine` by 2,
+	; making Obj52_Mobile read an invalid entry from off_2FD0E and crash the game.
 	bsr.w	loc_300A4
+    endif
 	bsr.w	loc_2FEDE
 	lea	(Ani_obj52).l,a1
 	bsr.w	AnimateBoss
+    if fixBugs
+	; See above.
+	bsr.w	loc_300A4
+    endif
 	jmpto	JmpTo36_DisplaySprite
 ; ===========================================================================
 
@@ -76269,7 +76278,7 @@ ObjA7_GrabCharacter:
 	; just floating in the air, and when the player touches the ground,
 	; they'll dash off. To fix this, just clear the player's Spin Dash
 	; flag, like this:
-	clr.b spindash_flag(a1)
+	clr.b	spindash_flag(a1)
     endif
 	move.b	#1,mapping_frame(a0)
 	tst.w	y_vel(a0)

--- a/s2.asm
+++ b/s2.asm
@@ -82521,6 +82521,8 @@ ObjC7_SetupEnding:
 	move.b	(Vint_runcount+3).w,d0
 	andi.b	#$1F,d0
 	bne.s	+
+	; PlaySound ends up being clogged up by the explosion sounds, both in
+	; the queue and sound channels, meaning this is effectively useless.
 	moveq	#signextendB(SndID_Rumbling2),d0
 	jsrto	JmpTo12_PlaySound
 	subq.w	#1,objoff_2A(a0)
@@ -82577,7 +82579,13 @@ loc_3D9D6:
 	dbf	d6,-
 
 	moveq	#signextendB(MusID_FadeOut),d0
+    if fixBugs
+	jsr	(PlayMusic).l
+    else
+	; PlaySound ends up being clogged up by the explosion sounds, 
+	; preventing the music from fading out as it should.
 	jsrto	JmpTo12_PlaySound
+    endif
 	move.b	#GameModeID_EndingSequence,(Game_Mode).w ; => EndingSequence
 	jmpto	JmpTo65_DeleteObject
 ; ===========================================================================

--- a/s2.asm
+++ b/s2.asm
@@ -80383,11 +80383,17 @@ ObjC0_SubObjData:
 ; sprite mappings
 ; ----------------------------------------------------------------------------
 ObjC0_MapUnc_3C098:	include "mappings/sprite/objC0.asm"
+
 ; ===========================================================================
-; ----------------------------------------------------------------------------
+; ---------------------------------------------------------------------------
 ; Object C1 - Breakable plating from WFZ
 ; (and what Sonic hangs onto on the back of Robotnik's getaway ship)
-; ----------------------------------------------------------------------------
+; ---------------------------------------------------------------------------
+; OST Variables:
+plating_time		= objoff_30	; time between grabbing the plating & breaking
+plating_grabbed		= objoff_32	; flag set when Sonic/Tails grab the plating
+plating_unk		= objoff_3F	; seems to be used to determine how long some plates hold on
+					; for after breaking until they fly off
 ; Sprite_3C0AC:
 ObjC1:
 	moveq	#0,d0
@@ -80399,66 +80405,68 @@ ObjC1:
 ObjC1_Index:	offsetTable
 		offsetTableEntry.w ObjC1_Init	; 0
 		offsetTableEntry.w ObjC1_Main	; 2
-		offsetTableEntry.w ObjC1_Breakup	; 4
+		offsetTableEntry.w ObjC1_FallOff	; 4
 ; ===========================================================================
 ; loc_3C0C0:
 ObjC1_Init:
 	move.w	#($44<<1),d0
 	bsr.w	LoadSubObject_Part2
 	moveq	#0,d0
+	; Yes, this is actually configurable, but in practice is redundant
+	; since all of them are set to break after 2 seconds.
 	move.b	subtype(a0),d0
-	mulu.w	#60,d0
-	move.w	d0,objoff_30(a0)
+	mulu.w	#60,d0			; multiply by 60 (1 second)
+	move.w	d0,plating_time(a0)	; set breakage time
 
 ObjC1_Main:
-	tst.b	objoff_32(a0)
-	beq.s	loc_3C140
-	tst.w	objoff_30(a0)
+	tst.b	plating_grabbed(a0)	; has plating already been grabbed?
+	beq.s	ObjC1_Grab		; if not, branch
+	tst.w	plating_time(a0)
 	beq.s	+
-	subq.w	#1,objoff_30(a0)
-	beq.s	loc_3C12E
+	subq.w	#1,plating_time(a0)	; decrement time until break
+	beq.s	ObjC1_Release
 +
 	lea	(MainCharacter).w,a1 ; a1=character
 	move.w	y_pos(a0),d0
 	subi.w	#$18,d0
-	btst	#button_up,(Ctrl_1_Held).w
-	beq.s	+
-	subq.w	#1,y_pos(a1)
+	btst	#button_up,(Ctrl_1_Held).w	; is Up being pressed?
+	beq.s	+			; if not, branch
+	subq.w	#1,y_pos(a1)		; move Sonic up
 	cmp.w	y_pos(a1),d0
-	blo.s	+
+	blo.s	+			; but stop if he's about to fall off
 	move.w	d0,y_pos(a1)
 +
 	addi.w	#$30,d0
-	btst	#button_down,(Ctrl_1_Held).w
-	beq.s	+
-	addq.w	#1,y_pos(a1)
+	btst	#button_down,(Ctrl_1_Held).w	; is Down being pressed?
+	beq.s	+			; if not, branch
+	addq.w	#1,y_pos(a1)		; move Sonic down
 	cmp.w	y_pos(a1),d0
-	bhs.s	+
+	bhs.s	+			; but stop if he's about to fall off
 	move.w	d0,y_pos(a1)
 +
 	move.b	(Ctrl_1_Press_Logical).w,d0
-	andi.w	#button_B_mask|button_C_mask|button_A_mask,d0
-	beq.s	BranchTo16_JmpTo39_MarkObjGone
-
-loc_3C12E:
+	andi.w	#button_B_mask|button_C_mask|button_A_mask,d0	; is A/B/C being pressed?
+	beq.s	BranchTo16_JmpTo39_MarkObjGone		; if not, branch
+; loc_3C12E:
+ObjC1_Release:
 	clr.b	collision_flags(a0)
 	clr.b	(MainCharacter+obj_control).w
 	clr.b	(WindTunnel_holding_flag).w
-	clr.b	objoff_32(a0)
-	bra.s	loc_3C19A
+	clr.b	plating_grabbed(a0)
+	bra.s	ObjC1_BeginBreakup
 ; ===========================================================================
-
-loc_3C140:
-	tst.b	collision_property(a0)
-	beq.s	BranchTo16_JmpTo39_MarkObjGone
+; loc_3C140:
+ObjC1_Grab:
+	tst.b	collision_property(a0)		; has Sonic touched the plating?
+	beq.s	BranchTo16_JmpTo39_MarkObjGone	; if not, branch
 	lea	(MainCharacter).w,a1 ; a1=character
 	move.w	x_pos(a0),d0
 	subi.w	#$14,d0
 	cmp.w	x_pos(a1),d0
 	bhs.s	BranchTo16_JmpTo39_MarkObjGone
 	clr.b	collision_property(a0)
-	cmpi.b	#4,routine(a1)
-	bhs.s	BranchTo16_JmpTo39_MarkObjGone
+	cmpi.b	#4,routine(a1)			; is Sonic hurt, dying, etc?
+	bhs.s	BranchTo16_JmpTo39_MarkObjGone	; if yes, branch
 	clr.w	x_vel(a1)
 	clr.w	y_vel(a1)
 	move.w	x_pos(a0),d0
@@ -80466,23 +80474,23 @@ loc_3C140:
 	move.w	d0,x_pos(a1)
 	bset	#status.player.x_flip,status(a1)
 	move.b	#AniIDSonAni_Hang,anim(a1)
-	move.b	#1,(MainCharacter+obj_control).w
-	move.b	#1,(WindTunnel_holding_flag).w
-	move.b	#1,objoff_32(a0)
+	move.b	#1,(MainCharacter+obj_control).w	; lock controls
+	move.b	#1,(WindTunnel_holding_flag).w		; disable wind tunnel
+	move.b	#1,plating_grabbed(a0)		; begin break timer
 
 BranchTo16_JmpTo39_MarkObjGone ; BranchTo
 	jmpto	JmpTo39_MarkObjGone
 ; ===========================================================================
-
-loc_3C19A:
-	lea	(byte_3C1E4).l,a4
-	lea	(byte_3C1E0).l,a2
+; loc_3C19A:
+ObjC1_BeginBreakup:
+	lea	(ObjC1_Positions).l,a4
+	lea	(ObjC1_BreakTimes).l,a2
 	bsr.w	loc_3C1F4
-
-ObjC1_Breakup:
-	tst.b	objoff_3F(a0)
+; ObjC1_Breakup:
+ObjC1_FallOff:
+	tst.b	plating_unk(a0)
 	beq.s	+
-	subq.b	#1,objoff_3F(a0)
+	subq.b	#1,plating_unk(a0)
 	bra.s	++
 ; ===========================================================================
 +
@@ -80502,22 +80510,23 @@ Ani_objC1:	offsetTable
 +		dc.b   3,  2,  3,  4,  5,  1,$FF
 		even
 
-; unknown
-byte_3C1E0:
+; Time (in frames) to wait until breaking off the aircraft
+; byte_3C1E0:
+ObjC1_BreakTimes:
 	dc.b   0
 	dc.b   4	; 1
 	dc.b $18	; 2
 	dc.b $20	; 3
 	even
-byte_3C1E4:
-	dc.w  -$10
-	dc.w  -$10	; 2
-	dc.w  -$10	; 4
-	dc.w   $10	; 6
-	dc.w  -$30	; 8
-	dc.w  -$10	; 10
-	dc.w  -$30	; 12
-	dc.w   $10	; 14
+
+; Positions each breaking plate starts at
+; byte_3C1E4:
+ObjC1_Positions:
+	; x-position, y-position
+	dc.w  -$10,-$10
+	dc.w  -$10, $10
+	dc.w  -$30,-$10
+	dc.w  -$30, $10
 ; ===========================================================================
 
 loc_3C1F4:
@@ -80553,7 +80562,7 @@ loc_3C20E:
 	move.b	#1,mapping_frame(a1)
 	move.w	#-$400,x_vel(a1)
 	move.w	#0,y_vel(a1)
-	move.b	(a2)+,objoff_3F(a1)
+	move.b	(a2)+,plating_unk(a1)
 	dbf	d1,loc_3C208
 
 loc_3C26C:
@@ -80563,10 +80572,11 @@ loc_3C26C:
 ; off_3C276:
 ObjC1_SubObjData:
 	subObjData ObjC1_MapUnc_3C280,make_art_tile(ArtTile_ArtNem_BreakPanels,3,1),1<<render_flags.level_fg,4,$40,$E1
-; ----------------------------------------------------------------------------
+; ---------------------------------------------------------------------------
 ; sprite mappings
-; ----------------------------------------------------------------------------
+; ---------------------------------------------------------------------------
 ObjC1_MapUnc_3C280:	include "mappings/sprite/objC1.asm"
+
 ; ===========================================================================
 ; ----------------------------------------------------------------------------
 ; Object C2 - Rivet thing you bust to get into ship at the end of WFZ

--- a/s2.asm
+++ b/s2.asm
@@ -14147,7 +14147,7 @@ ObjCD_Index:	offsetTable
 ; ===========================================================================
 ; loc_AAC0:
 ObjCD_Init:
-	lea	(Obj28_SubObjData).l,a1
+	lea	(ObjCD_SubObjData).l,a1
 	jsrto	JmpTo_LoadSubObject_Part3
 	move.l	(RNG_seed).w,d0
 	ror.l	#3,d0
@@ -14342,8 +14342,14 @@ ChildObject_AD6A:	childObjectData objoff_3E, ObjID_EndingSeqSonic, $00
 ChildObject_AD6E:	childObjectData objoff_3E, ObjID_TornadoHelixes, $00
 
 ; off_AD72:
-Obj28_SubObjData:
+ObjCD_SubObjData:
+    if fixBugs
+	subObjData Obj28_MapUnc_11E1C,make_art_tile(ArtTile_ArtNem_Animal_2,0,0),1<<render_flags.level_fg,1,8,0
+    else
+	; This should use priority 1, not 2. As-is, it causes the birds to
+	; overlap the Tornado but appear behind Sonic.
 	subObjData Obj28_MapUnc_11E1C,make_art_tile(ArtTile_ArtNem_Animal_2,0,0),1<<render_flags.level_fg,2,8,0
+    endif
 
 ; animation script
 ; byte_AD7C
@@ -15645,13 +15651,25 @@ SwScrl_WFZ:
 	lea	(TempArray_LayerDef).w,a2
 	move.l	d0,(a2)+				; Static parts of BG (generally no clouds in them)
 	move.l	d1,(a2)+				; Eggman's getaway ship
-	; Note: this is bugged: this tallies only the cloud speeds. It works fine
-	; if you are standing still, but makes the clouds move faster when going
-	; right and slower when going left. This is exactly the opposite of what
-	; should happen.
-	addi.l	#$8000,(a2)+			; Larger clouds
-	addi.l	#$4000,(a2)+			; Medium clouds
-	addi.l	#$2000,(a2)+			; Small clouds
+    if fixBugs
+	moveq	#0,d5
+	move.w	(Camera_X_pos_diff).w,d5	; get camera x-diff
+	ext.l	d5
+	asl.l	#5,d5
+	add.l	d5,(a2)				; add to high word of accumulation
+	addi.l	#$8000,(a2)+			; larger clouds
+	add.l	d5,(a2)
+	addi.l	#$4000,(a2)+			; medium clouds
+	add.l	d5,(a2)
+	addi.l	#$2000,(a2)+			; small clouds
+    else
+	; This tallies only the cloud speeds. It works fine if you are standing
+	; still, but makes the clouds move faster when going right and slower when
+	; going left. This is exactly the opposite of what should happen.
+	addi.l	#$8000,(a2)+			; larger clouds
+	addi.l	#$4000,(a2)+			; medium clouds
+	addi.l	#$2000,(a2)+			; small clouds
+    endif
 	lea	(SwScrl_WFZ_Transition_Array).l,a3
 	cmpi.w	#$2700,(Camera_X_pos).w
 	bhs.s	.got_array
@@ -73777,10 +73795,11 @@ Obj94_SolidCollision:
 Obj94_PostCreateHead:
 	bsr.s	Obj94_SolidCollision
 	jmpto	JmpTo39_MarkObjGone
+
 ; ===========================================================================
-; ----------------------------------------------------------------------------
+; ---------------------------------------------------------------------------
 ; Object 97 - Rexon's head, from HTZ
-; ----------------------------------------------------------------------------
+; ---------------------------------------------------------------------------
 ; Sprite_373D0:
 Obj97:
 	moveq	#0,d0


### PR DESCRIPTION
Not much to say. ObjC1 was modified from Obj0B in _Sonic 1_, with the only real changes being its graphics and breaking animation. Curiously, the time Sonic can hold onto the plating is actually configurable with `subtype`, but this functionality effectively goes unused due to them all being set to break after 2 seconds.

Other than that, I documented the two sound queuing bugs with the Death Egg Robot I posted about a few days ago, as well as (finally) adding the fixes for the HTZ boss crash and incorrect WFZ cloud scrolling speeds. `Obj28_SubObjData` had its label corrected (it was actually for ObjCD, the ending birds) and its own fix relating to sprite priority.